### PR TITLE
Fix rc-local.service install error

### DIFF
--- a/Mangdang/System/install.sh
+++ b/Mangdang/System/install.sh
@@ -5,6 +5,6 @@ sudo cp 20auto-upgrades /etc/apt/apt.conf.d/
 sudo chmod 440 sudoers
 sudo cp sudoers  /etc/
 sudo cp rc.local /etc/
-sudo cp rc.local.service /lib/systemd/system/
+sudo cp rc-local.service /lib/systemd/system/
 sudo systemctl enable rc-local
 sudo systemctl start rc-local.service

--- a/Mangdang/System/rc-local.service
+++ b/Mangdang/System/rc-local.service
@@ -24,5 +24,5 @@ GuessMainPID=no
 
 [Install]
 WantedBy=multi-user.target
-Alias=rc-local.service
+Alias=rc.local.service
 


### PR DESCRIPTION
This PR fixes the rc-local.service install error.
ref: https://github.com/mangdangroboticsclub/minipupper_ros_bsp/pull/2

The current install script shows the following output while installing.

```
++ sudo systemctl enable rc-local
The unit files have no installation config (WantedBy=, RequiredBy=, Also=,
Alias= settings in the [Install] section, and DefaultInstance= for template
units). This means they are not meant to be enabled using systemctl.
 
Possible reasons for having this kind of units are:
• A unit may be statically enabled by being symlinked from another unit's
  .wants/ or .requires/ directory.
• A unit's purpose may be to act as a helper for some other unit which has
  a requirement dependency on it.
• A unit may be started when needed via activation (socket, path, timer,
  D-Bus, udev, scripted systemctl call, ...).
• In case of template units, the unit is meant to be enabled with some
  instance name specified.
```